### PR TITLE
update function, settings, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@ MoveApps
 Github repository: github.com/movestore/Upload-File-from-Local
 
 ## Description
-Upload tracking data as moveStack, move2_location (rds) and/or csv table from your local system. The data will be transformed to a move2_loc object and appended to possible App input data.
+Upload tracking data as moveStack, move2 (rds) and/or csv table from your local system. The data will be transformed to a move2_loc object and appended to possible App input data.
 
 ## Documentation
 The App reads either an rds file and/or a csv table of tracking location data. The data are transformed to a move2_loc object so they can be analysed with many other Apps in a workflow. In case this App is not the start of a workflow and has input data, the input data and the newly read data are combined/stacked in a move2 object with renaming of all tracks if any track IDs are the same in both (or all) objects.
 
 If the data is a move2 object in an rds file, it is read in without any changes. If it is a moveStack (soon to be deprecated), then it is transformed to a move2 object.
 
-If the data is a csv table with location data, it is required that the data contain a column defining the track, one column to define the timestamp and two/three columns defining the location. The names of these columns can be provided/adapted in the settings of the App. Furthermore, it is necessary to specify the crs/projection of the coordinate system the locations were taken in, the default is WGS84. Finally, track attributes can be specified, that will then be saved separately in the move2 object, avoiding a lot of dupliated data.
+If the data is a csv table with location data, it is required that the data contain a column defining the track, one column to define the timestamp (see expected format in 'Settings') and two/three columns defining the location. The names of these columns have to be provided in the settings of the App. Furthermore, it is necessary to specify the crs/projection of the coordinate system the locations were taken in, the default is EPSG:4326. Finally, track attributes can be specified, that will then be saved separately in the move2 object, avoiding a lot of duplicated data.
 
-It is possible to combine a csv and an rds file, but track identifiers and all the above specified attributes need to be the same.
+It is possible to upload simultaneously a csv and an rds file, these will be than combined into one object.
 
 ...
 
@@ -31,15 +31,17 @@ move2::move2_loc object - being the input integrated with additionally uploaded 
 none
 
 ### Settings 
-`Name of the time column` (time_col): Column to use as the timestamp column for the transformation of the table data to a move2 object. Default "timestamp".
+`Name of the time column` (time_col): Column to use as the timestamp column for the transformation of the table data to a move2 object. The expected timestamp format is 'yyyy-mm-dd HH:MM:SS' and in UTC timezone. Default "timestamp".
 
-`Name of the track ID column` (track_id_col): Column to use as the track ID column for transforamtion of the table data to a move2 object. Duplicated timestamps in a track should be avoided. Beware of possible issues if you have reused tags on different animals or used several tags on the same animal. Then, the use of "deployment.id", as in the default, can be useful. Else, "individual.local.identifier" might be preferred.
+`Name of the track ID column` (track_id_col): Column to use as the track ID column for transformation of the data table to a move2 object. Beware of possible issues if you have reused tags on different animals or used several tags on the same animal. If this is the case, create a column before uploading the data with a unique identifier for each animal and tag combination, e.g. by creating a 'animalName_TagID' column. Default "individual-local-identifier".
 
-`ame of the attributes to become track attributes` (track_attr): List of attributes that are pure track attributes, i.e. have only one value per track. This will make working with the data easier in subsequent Apps. The names must be separated with comma. Default is the empty string "", i.e. no tack attributes.
+`Name of the attributes to become track attributes` (track_attr): List of attributes that are pure track attributes, i.e. have only one value per track. This will make working with the data easier in subsequent Apps. The names must be separated with comma. Default is the empty string "", i.e. no tack attributes.
 
-`Names of the longigute and latitute columns` (coords): Names of the two (or three) coordinate columns in your data for correct transformation to a move2 object. The order must be x/longitude followed by y/latitute and optionally z/height. The names must be separated with comma. Default: "location.long, location.lat".
+`Names of the longitude and latitute columns` (coords): Names of the two (or three) coordinate columns in your data for correct transformation to a move2 object. The order must be x/longitude followed by y/latitute and optionally z/height. The names must be separated with comma. Default: "location-long, location-lat".
 
-`Coordinate reference system` (crss): Coordinate reference system/ projection to use, either as character, number (EPSG) or a crs object. Default "WGS84" (standard longitude/latitude)
+`Coordinate reference system` (crss): Coordinate reference system/ projection to useas a valid numeric EPSG value. For more info see https://epsg.io/ and https://spatialreference.org/. Default 4326 (EPSG:4326, standard longitude/latitude)
+
+`Duplicate Handling` (duplicates_handling): Records with the same track ID and timestamp can cause errors, for example by requiring an animal to be in two places at the same time, and therefore are not allowed. If present in the data set, the duplicated timestamp entry with least columns containing NAs is retained. As thereafter there can still exist duplicates these will be removed based on the selected option (1) The first location of each set of duplicates, (2) The last location of each set of duplicates or (3) A randomly selected location from set of duplicates. Default: (1) The first location of each set of duplicates.
 
 `Tracking data in csv format` (csvFile_ID): Local, comma-separated csv file of tracking data to be uploaded, called 'data.csv' (this file name is compulsory). Attribute names of key properties can be indicated in the settings above. Please take care to adapt them.
 
@@ -47,12 +49,12 @@ none
 
 
 ### Most common errors
-none yet, but please make an issue here, if you repeatedly run into problems.
+none yet, but please make an issue [here](https://github.com/movestore/Upload-File-from-Local/issues), if you repeatedly run into problems.
 
 ### Null or error handling
 
 **Settings `column names`:** Take care that the spelling is correct, else the App will run into an error.
 
-**Settings `crss`:** If this is not a proper crs string or EPSG number, the App wil run into an error. With the default of `WGS84` data from Movebank are fine.
+**Settings `crss`:** If this is not a correct EPSG number, the App wil run into an error. The default of `4326` is the correct projection for data from Movebank.
 
 **Settings `file upload`:** Take care to rename your files according to what the app expects (data.csv or data.rds), else the App cannot find the data and will not add the tracks. Instead the original input data or NULL will be returned.

--- a/RFunction.R
+++ b/RFunction.R
@@ -1,110 +1,140 @@
 library('move2')
 library('move')
+library('vroom')
+library('dplyr')
+library('sf')
 
-rFunction = function(data=NULL, time_col="timestamp", track_id_col="deployment_id", track_attr="",coords="location_long,location_lat",crss="WGS84", ...) {
+# vroom reads in the data as is, csv from MB is with "-" in column names
+# the csv file is expected to be comma delimited
+# The expected timestamp format is 'yyyy-mm-dd HH:MM:SS' and in UTC timezone
+# The expected projection is a valid numeric EPSG value. E.g 4326 (EPSG:4326 is lat/lon)
+
+rFunction  <-  function(data=NULL, time_col="timestamp", track_id_col="individual-local-identifier", track_attr="",coords="location-long,location-lat",crss=4326, duplicates_handling= "first", ...){ 
   
   # rds file # works :)
   fileName1 <- paste0(getAppFilePath("rdsFile_ID"), "data.rds") #default is NULL
   logger.info(paste("Reading file", fileName1,"of size:", file.info(fileName1)$size,"."))
   new1 <- readRDS(fileName1)
   
-  # if move2 object - fine, else transform moveStack to move2
-  if (is.null(new1)) logger.info("No new rds data found.") else logger.info("New data uploaded from rds file.")
-  if (!is.null(new1) & any(class(new1)=="MoveStack")) 
-  {
-    new1 <- mt_as_move2(new1)
-    logger.info("Uploaded rds file containes a moveStack object that is transformed to move2.")
+  if(is.null(new1)){logger.info("No new rds data found.")
+  } else { 
+    # if .rds is move2
+    if(any(class(new1)=="move2")){logger.info("Uploaded rds file containes a object of class move2")}
+    # if move2 object - fine, else transform moveStack to move2
+    if(any(class(new1)=="MoveStack")){
+      new1 <- mt_as_move2(new1)
+      logger.info("Uploaded rds file containes a object of class moveStack that is transformed to move2.")
+    }
+    if(!any(class(new1)%in%c("move2","MoveStack"))){
+      new1 <- NULL
+      logger.info("Uploaded rds file contains data with unexpected class, please ensure that the file contains a object of class 'move2' or 'MoveStack'.")}
+  }
+  # make names for new1
+  if(!is.null(new1)){
+    names(new1) <- make.names(names(new1),allow_=TRUE)
+    track_id(new1) <- make.names(track_id(new1),allow_=TRUE)
   }
   
-  # make names for new1
-  names(new1) <- make.names(names(new1),allow_=TRUE)
-  track_id(new1) <- make.names(track_id(new1),allow_=TRUE)
   
   # csv file
   fileName2 <- paste0(getAppFilePath("csvFile_ID"), "data.csv") #default is NULL
   logger.info(paste("Reading file", fileName2,"of size:", file.info(fileName2)$size,"."))
-  try(df2 <- read.csv(fileName2,header=TRUE),silent=TRUE)
-  if (!exists("df2")) df2 <- NULL
-  
-  if(is.null(df2)) logger.info("No new csv data found. The settings of the App are not used.") else {
-    logger.info("New data uploaded from csv file.")
-    logger.info(paste("You have defined as time column:",time_col,"."))
-    logger.info(paste("You have defined as track ID column:",track_id_col,"."))
-    logger.info(paste("You have defined as track attributes:",track_attr,"."))
-    #this only if a comma in the data!
-    if(length(grep(",",track_attr))>0) tr_attr <- trimws(strsplit(as.character(track_attr),",")[[1]]) else tr_attr <- track_attr
+  try(df2 <-  vroom::vroom(fileName2, delim = ",")) # alternative to read.csv, takes care of timestamps, default timezome is UTC
+  if (!exists("df2")){
+    df2 <- NULL
+    logger.info("No new csv data found. The settings of the App are not used.")
+  } 
+  if(length(grep(",",coords)) %in% c(1,2)){
+    coo <- trimws(strsplit(as.character(coords),",")[[1]])
     logger.info(paste("You have defined as coordinate columns:",coords,"."))
-    if(length(grep(",",coords)) %in% c(1,2)) coo <- trimws(strsplit(as.character(coords),",")[[1]]) else {
-          coo <- NULL
-          logger.info("An incorrect number of coordinate columns is provided; expecting two (x,y) or three (x,y,z). Cannot transform csv data to move2.")
-          df2 <- NULL
-    }
-    logger.info(paste("You have defined as projection (crs):",crss,"."))
+  } else {
+    coo <- NULL
+    logger.info("An incorrect number of coordinate columns is provided; expecting two (x,y) or three (x,y,z). Cannot transform csv data to move2.")
+    df2 <- NULL
   }
-
-  # transform data.frame to move2 object
-  if (!is.null(df2)) new2 <- mt_as_move2(df2,time_column=time_col,track_id_column=track_id_col,track_attributes=tr_attr,coords=coo,crs=crss,na.fail=FALSE) else new2 <- NULL #na.fail ok?
-
-  # make names for new2
-  names(new2) <- make.names(names(new2),allow_=TRUE)
-  mt_track_id(new2) <- make.names(mt_track_id(new2),allow_=TRUE)
+  if(!is.null(df2)){
+    logger.info("New data uploaded from csv file, this file is expected to be comma delimited.")
+    logger.info(paste("You have defined as datetime column: ",time_col,".", " The expected timestamp format is 'yyyy-mm-dd HH:MM:SS' and in UTC timezone"))
+    logger.info(paste("You have defined as track ID column: ",track_id_col,"."))
+    logger.info(paste("You have defined as track attributes: ",track_attr,"."))
+    logger.info(paste("You have defined as projection (crs): ",crss,".", " The expected projection is a valid numeric EPSG value. For more info see https://epsg.io/ and https://spatialreference.org/"))
+    
+    #this only if a comma in the data!
+    if(length(grep(",",track_attr))>0){tr_attr <- trimws(strsplit(as.character(track_attr),",")[[1]])} else {tr_attr <- track_attr}
+    
+    # transform data.frame to move2 object
+    df2 <- dplyr::filter(df2,!is.na(df2[[track_id_col]])) # if there is a NA in the track_id col, mt_as_move2() gives error
+    new2 <- mt_as_move2(df2,
+                        time_column=time_col,
+                        track_id_column=track_id_col,
+                        track_attributes=track_attr,
+                        coords=coo,
+                        crs=crss,
+                        na.fail=FALSE)
+    ## remove empty locations
+    new2 <- new2[!sf::st_is_empty(new2),]  
+    if(nrow(new2)==0){logger.info("Your uploaded csv file does not contain any location data.")}
+    
+    ## remove duplicated timestamps
+    if(!mt_has_unique_location_time_records(new2)){
+      n_dupl <- length(which(duplicated(paste(mt_track_id(new2),mt_time(new2)))))
+      logger.info(paste("Your data has",n_dupl, "duplicated location-time records. We removed here those with less info and then select the",duplicates_handling,"if still duplicated."))
+      if(any(c("event_id", "event-id", "event.id") %in% names(new2))){ ## event id is always different for all entries, so excluding it when looking for duplicates
+        new2 <- mt_filter_unique(dplyr::select(new2, -starts_with("event")),criterion="subsets") # hope ignoring all event... columns is ok
+      } else {
+        new2 <- mt_filter_unique(new2,criterion="subsets")
+      }
+      new2 <- mt_filter_unique(new2,criterion=duplicates_handling)
+    }
+    
+    ## ensure timestamps are ordered within tracks
+    new2 <- dplyr::arrange(new2, mt_track_id(new2), mt_time(new2)) 
+    
+    # make names for new2
+    names(new2) <- make.names(names(new2),allow_=TRUE)
+    mt_track_id(new2) <- make.names(mt_track_id(new2),allow_=TRUE)
+  }
+  if(is.null(df2)){new2 <- NULL} #na.fail ok?
+  if(nrow(new2)==0){new2 <- NULL}
+  
   
   # here is where the object data is needed
-  if (!exists("data") | is.null(data) | length(data)==0) #here need to check what is possible (Clemens)
-  {
-    if(is.null(new1))
-    {
-      if(is.null(new2)) 
-      {
+  if (!exists("data") | is.null(data) | length(data)==0){ #here need to check what is possible (Clemens)
+    if(is.null(new1)){
+      if(is.null(new2)){
         result <- NULL
         logger.info("No new data in rds or csv files and no input data from previous App. Returning NULL.") # works
-      } else
-      {
+      } else {
         result <- new2
         logger.info("New data uploaded from csv file.") # works
       }
-    } else
-    {
-      if(is.null(new2)) 
-      {
+    } else {
+      if(is.null(new2)){
         result <- new1
         logger.info("New data uploaded from rds file.") # works
-      } else
-      {
+      } else {
         result <- mt_stack(new1,new2,.track_combine="rename")
-        logger.info("New data uploaded from rds and csv files. Both data sets are merged.") #does not work: problem with mt_stack() 
-        #[INFO] You have defined as projection (crs): WGS84 .
-        #[1] "ERROR:  \033[1m\033[33mError\033[39m:\033[22m\n\033[33m!\033[39m Can't combine `..1` <factor<7244e>> and `..2` <integer>.\n"
+        logger.info("New data uploaded from rds and csv files. Both data sets are merged.") # works
       }   
     }
-  } else
-  {
-    if(is.null(new1))
-    {
-      if(is.null(new2)) 
-      {
+  } else {
+    if(is.null(new1)){
+      if(is.null(new2)){
         result <- data
         logger.info("No new data in rds or csv files. Returning input data.") # works
-      } else
-      {
+      } else {
         result <- mt_stack(data,new2,.track_combine="rename")
-        logger.info("New data uploaded from csv file and appended to input data.") # does not work, error in mt_stack
-        #Error in (function (..., .ptype = NULL, .name_spec = NULL, .name_repair = c("minimal", :
-        #Can't combine `..1` <factor<27461>> and `..2` <integer>.
+        logger.info("New data uploaded from csv file and appended to input data.") # works
       }
-    } else
-    {
-      if(is.null(new2)) 
-      {
+    } else {
+      if(is.null(new2)){
         result <- mt_stack(data,new1,.track_combine="rename")
         logger.info("New data uploaded from rds file and appended to input data.") # works for move1 and move2
-      } else
-      {
+      } else {
         result <- mt_stack(data,new1,new2,.track_combine="rename")
-        logger.info("New data uploaded from rds and csv files. Both data sets are appended to input data.") # didnt try, but if other cases dont work, likely not
+        logger.info("New data uploaded from rds and csv files. Both data sets are appended to input data.") # works
       }   
     }
   }
-
   return(result)
 }

--- a/appspec.json
+++ b/appspec.json
@@ -3,37 +3,56 @@
     {
       "id": "time_col",
       "name": "Name of the time column",
-      "description": "Indicate which column to use as the timestamp column for the transformation of the table data to a move2 object. Take care to enter the name in the correct spelling, see the data summary of the preceding App.",
+      "description": "Indicate which column to use as the timestamp column for the transformation of the table data to a move2 object. Take care to enter the name with the correct spelling. The expected timestamp format is 'yyyy-mm-dd HH:MM:SS' and in UTC timezone.",
       "defaultValue": "timestamp",
       "type": "STRING"
     },
     {
       "id": "track_id_col",
       "name": "Name of the track ID column",
-      "description": "Indicate which column to use as the track ID column for transforamtion of the table data to a move2 object. Take care that duplicated timestamps in a track are not allowed. Beware of possible issues if you have reused tags on different animals or used several tags on the same animal. Then, the use of deployment.id, as in the default, can be useful. Else, individual.local.identifier might be preferred. Take care to enter the attributes' names in the correct spelling, see the data summary of the preceding App.",
-      "defaultValue": "deployment_id",
+      "description": "Indicate which column to use as the track ID column for transforamtion of the table data to a move2 object. Take care to enter the name with the correct spelling. Beware of possible issues if you have reused tags on different animals or used several tags on the same animal. If this is the case, create a column before uploading the data with a unique identifier for each animal and tag combination, e.g. by creating a 'animalName_TagID' column.",
+      "defaultValue": "individual-local-identifier",
       "type": "STRING"
     },
 	    {
       "id": "track_attr",
       "name": "Name of the attributes to become track attributes",
-      "description": "List which of the attributes are pure track attributes, i.e. have only one value per track. This will make working with the data easier in subsequent Apps. Take care to enter the attributes' names in the correct spelling, see the data summary of the preceding App. The names must be separated with comma.",
+      "description": "List which of the attributes are pure track attributes, i.e. have only one value per track. This will make working with the data easier in subsequent Apps. Take care to enter the attributes' names in the correct spelling. The names must be separated with comma.",
       "defaultValue": "",
       "type": "STRING"
     },
 	    {
       "id": "coords",
       "name": "Names of the longigute and latitute columns.",
-      "description": "Provide the names of the two (or three) coordinate columns in your data for correct transformation to a move2 object. The order must be x/longitude followed by y/latitute and optionally z/height. Take care to enter the attributes' names in the correct spelling, see the data summary of the preceding App. The names must be separated with comma.",
-      "defaultValue": "location_long, location_lat",
+      "description": "Provide the names of the two (or three) coordinate columns in your data for correct transformation to a move2 object. The order must be x/longitude followed by y/latitute and optionally z/height. Take care to enter the attributes' names in the correct spelling. The names must be separated with comma.",
+      "defaultValue": "location-long, location-lat",
       "type": "STRING"
     },
 	    {
       "id": "crss",
       "name": "Coordinate reference system.",
-      "description": "Enter the coordinate reference system/ projection to use, either as character, number (EPSG) or a crs object.",
-      "defaultValue": "WGS84",
-      "type": "STRING"
+      "description": "Enter the coordinate reference system/ projection to use as a valid numeric EPSG value. For more info see https://epsg.io/ and https://spatialreference.org/.",
+      "defaultValue": 4326,
+      "type": "INTEGER"
+    },
+    {
+      "id": "duplicates_handling",
+      "name": "Duplicate Handling.",
+      "description": "Records with the same track ID and timestamp can cause errors in subsequent steps of your workflow, for example by requiring an animal to be in two places at the same time, and therefore are not allowed. If present in this data set, the duplicated timestamp entry with least columns containing NAs is retained. As thereafter there can still exist duplicates choose which one to retain:",
+      "type": "RADIOBUTTONS",
+       "defaultValue": "first",
+  "options": [{
+      "value": "first",
+      "displayText": "The first location of each set of duplicates"
+    },
+    {
+      "value": "last",
+      "displayText": "The last location of each set of duplicates"
+    },
+    {
+      "value": "sample",
+      "displayText": "A randomly selected location from set of duplicates"
+    }]
     },
 	    {
       "id": "csvFile_ID",
@@ -50,12 +69,11 @@
   ],
   "dependencies": {
     "R": [
-      {
-        "name": "move"
-      },
-      {
-        "name": "move2"
-      }
+      {"name": "move"},
+      {"name": "move2"},
+      {"name": "vroom"},
+      {"name": "dplyr"},
+      {"name": "sf"}
     ]
   },
   "createsArtifacts": true,
@@ -79,6 +97,7 @@
 	"data access",
 	"rds",
 	"csv"
+	],
   "people": [
     {
      "firstName": "Andrea",
@@ -90,6 +109,16 @@
         "creator"
       ],
       "orcid": "0000-0003-0193-1563",
+      "affiliation": "Max-Planck-Institute of Animal Behavior",
+      "affiliationRor": "https://ror.org/026stee22"
+    },
+    {
+      "firstName": "Anne",
+      "middleInitials": "K",
+      "lastName": "Scharf",
+      "email": "ascharf@ab.mpg.de",
+      "roles": ["author"],
+      "orcid": "0000-0002-3357-8533",
       "affiliation": "Max-Planck-Institute of Animal Behavior",
       "affiliationRor": "https://ror.org/026stee22"
     }


### PR DESCRIPTION
Hi Andrea,
ich hab jetzt doch alle Veränderungen in der RFunction gemacht. Jetzt sollte es laufen und viele Situationen auffangen (hoffentlich!). Ich habe auch einiges in den settings und im readme angepasst/geändert. 
Hier ein paar Erklärungen dazu:
appspecs (and readme) changes justification:
- time column: "...see the data summary of the preceding app" - this does not work, as the csv uploaded is probably compleatly unrealted to the data in the WF, and might not even be from MB
- track id col: the colimn "deployment.id" only exists when you download the data via api, if you download via mb web page, this column is not present. I've added a option to select how to remove duplicate timestamps. Again, look at spelling from previous app does not make sense
- crs: "character: a string accepted by GDAL" (sf)- thats why I removed that posibility, and a object of class crs also cannot be added as there is no posibility to upload it.

Mir ist dabei aufgefallen das man das duplicate handling in the movebank_download_move2 verbessern kann. Mach ich nächste Woche.

Schau dir alles mal an, und dann können wir gerne darüber sprechen :)